### PR TITLE
Fix diff path of expected files for bonus

### DIFF
--- a/srcs/diff_test.sh
+++ b/srcs/diff_test.sh
@@ -6,7 +6,7 @@
 #    By: jtoty <jtoty@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2017/01/23 18:26:48 by jtoty             #+#    #+#              #
-#    Updated: 2021/02/04 07:13:02 by lmartin          ###   ########.fr        #
+#    Updated: 2022/01/22 17:48:18 by fsoares-         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -62,7 +62,7 @@ diff_test()
 			printf "${COLOR_FAIL}T${DEFAULT}"
 			retvalue=0
 		else
-			DIFF=$(diff -U 3 "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d  . -f 1)/test${text}$k.output)
+			DIFF=$(diff -U 3 "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d  . -f 1 | sed 's/_bonus//g')/test${text}$k.output)
 			printf "$> diff -U 3 user_output_test${text}$k test${text}$k.output\n" >> "${PATH_DEEPTHOUGHT}"/deepthought
 			if [ "$DIFF" != "" ] || [ ! -e "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k ]
 			then


### PR DESCRIPTION
Currently there is a problem with the diff when checking the bonus functions output.

The path for the expected diff file is incorrect. The diff executed, but because it could not find the expected file it returned an empty diff, so the program assumed everything was ok