### PR TITLE
Bonus compilation fix

### DIFF
--- a/srcs/test_function.sh
+++ b/srcs/test_function.sh
@@ -90,7 +90,7 @@ test_function()
 				then
 					compilation $function
 				else
-					compilation $(echo ${function} | sed 's/_bonus//g')
+					compilation $(echo ${function})
 				fi
 				check_compilation
 				check=$?


### PR DESCRIPTION
There was an issue when compiling bonus functions, it tryed to compile without the "_bonus" extension.