### PR TITLE
revert bonus compilation

### DIFF
--- a/srcs/test_function.sh
+++ b/srcs/test_function.sh
@@ -90,7 +90,7 @@ test_function()
 				then
 					compilation $function
 				else
-					compilation $(echo ${function})
+					compilation $(echo ${function} | sed 's/_bonus//g')
 				fi
 				check_compilation
 				check=$?


### PR DESCRIPTION
Hi, it seems that the most recent commit is forcing all bonus files to end with "_bonus.c". A lot of my peers who recently validated libft before that change, are currently evaluating other students submitting libft and are having some misunderstandings since this tester shows that their functions do not compile. Please consider adding back this section of the script